### PR TITLE
fix: entrypoint.sh 파일 oj-backend 경로, oj-judge 경로 수정

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,13 +29,13 @@ sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plug
 ###############################################################
 
 git clone https://github.com/hepheir/oj-backend
-cd OnlineJudge
+cd oj-backend
 docker build -t hepheir/oj-backend .
 
 cd ..
 
 git clone https://github.com/hepheir/oj-judge
-cd JudgeServer
+cd oj-judge
 git submodule init
 git submodule update
 docker build -t hepheir/oj-judge .


### PR DESCRIPTION
# 관련 이슈
closed #1 

# 해결된 문제
- entrypoint.sh 파일 oj-backend 경로, oj-judge 경로 수정을 하였습니다

# 부족한 문제
- oj-judge의 도커 파일에 문제가 있어 고치고 싶습니다. (ubuntu 24 버전으로 한 결과 언어들이 버전이 불러와지지 않아 최신으로 맞추거나 새로운 버전으로 해야할 것 같습니다.)